### PR TITLE
解决 rn 0.57 无法 bundle 的问题

### DIFF
--- a/local-cli/src/bundle.js
+++ b/local-cli/src/bundle.js
@@ -405,7 +405,9 @@ export const commands = {
     if (major === 0) {
       if (minor >= 57) {
         // https://github.com/facebook/react-native/commit/a32620dc3b7a0ebd53feeaf7794051705d80f49e#diff-75692fe55c8b1a7c05f4264301342167L101
-        defaultConfig = Config.load();
+        // defaultConfig = Config.load();
+        const { configPromise } = require(path.resolve('node_modules/react-native/local-cli/core'));
+        defaultConfig = await configPromise;
       } else if (minor >= 45) {
         defaultConfig = Config.findOptional(path.resolve('.'));
       } else if (minor >= 42) {

--- a/local-cli/src/bundle.js
+++ b/local-cli/src/bundle.js
@@ -405,7 +405,7 @@ export const commands = {
     if (major === 0) {
       if (minor >= 57) {
         // https://github.com/facebook/react-native/commit/a32620dc3b7a0ebd53feeaf7794051705d80f49e#diff-75692fe55c8b1a7c05f4264301342167L101
-        defaultConfig = Config.load();
+        defaultConfig = await Config.load();
       } else if (minor >= 45) {
         defaultConfig = Config.findOptional(path.resolve('.'));
       } else if (minor >= 42) {

--- a/local-cli/src/bundle.js
+++ b/local-cli/src/bundle.js
@@ -405,7 +405,7 @@ export const commands = {
     if (major === 0) {
       if (minor >= 57) {
         // https://github.com/facebook/react-native/commit/a32620dc3b7a0ebd53feeaf7794051705d80f49e#diff-75692fe55c8b1a7c05f4264301342167L101
-        defaultConfig = await Config.load();
+        defaultConfig = Config.load();
       } else if (minor >= 45) {
         defaultConfig = Config.findOptional(path.resolve('.'));
       } else if (minor >= 42) {


### PR DESCRIPTION
在 `rn >= 0.57` 中运行 `pushy bundle` 会失败，返回如下等错误信息
```
Module `AccessibilityInfo` does not exist in the Haste module map
```

翻了下 `react-native` 的代码，如下修改后就可以 `bundle` 了，但还没测试这样 `bundle` 然后 `pack` 后可不可以热更新（后面的逻辑我没有研究过）