### PR TITLE
fix bug: solve warning triggered by constantsToExport

### DIFF
--- a/ios/RCTHotUpdate/RCTHotUpdate.m
+++ b/ios/RCTHotUpdate/RCTHotUpdate.m
@@ -135,6 +135,10 @@ RCT_EXPORT_MODULE(RCTHotUpdate);
     return [RCTHotUpdate binaryBundleURL];
 }
 
++ (BOOL)requiresMainQueueSetup {
+	return YES;
+}
+
 - (NSDictionary *)constantsToExport
 {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];


### PR DESCRIPTION
Fix bug like 

```
Module RCTHotUpdate requires main queue setup since it overrides `constantsToExport` 
but doesn't implement `requiresMainQueueSetup`. In a future release React Native will 
default to initializing all native modules on a background thread unless explicitly opted-out of.
```