### PR TITLE
🧪 [testing improvement] Add edge case tests for joinUrls

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -45,4 +45,29 @@ describe('joinUrls', () => {
       'https://cdn.example.com/base/file.txt',
     ]);
   });
+
+  test('handles empty string paths', () => {
+    expect(joinUrls([''], 'file.txt')).toEqual(['https:///file.txt']);
+  });
+
+  test('trims multiple trailing slashes', () => {
+    expect(joinUrls(['example.com///', 'http://example.com///'], 'file.txt')).toEqual([
+      'https://example.com/file.txt',
+      'http://example.com/file.txt',
+    ]);
+  });
+
+  test('preserves custom protocols', () => {
+    expect(joinUrls(['ftp://example.com', 'myapp://some/path'], 'file.txt')).toEqual([
+      'ftp://example.com/file.txt',
+      'myapp://some/path/file.txt',
+    ]);
+  });
+
+  test('prepends https:// to IP addresses with ports', () => {
+    expect(joinUrls(['192.168.1.1:8080', '10.0.0.1:3000/api'], 'file.txt')).toEqual([
+      'https://192.168.1.1:8080/file.txt',
+      'https://10.0.0.1:3000/api/file.txt',
+    ]);
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing edge case tests for `joinUrls` utility function. Added edge cases such as empty string paths, trimming multiple trailing slashes, preserving custom protocols (`ftp://`, `myapp://`), and properly prepending `https://` to IP addresses (with ports).
📊 **Coverage:** What scenarios are now tested: Empty string path arrays, URLs containing multiple trailing slashes (e.g., `example.com///`), IP addresses with ports, and URLs with non-HTTP custom protocols.
✨ **Result:** The improvement in test coverage: Improved confidence in `joinUrls` string-parsing resilience and overall regression prevention.

---
*PR created automatically by Jules for task [6270451404118664751](https://jules.google.com/task/6270451404118664751) started by @sunnylqm*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for URL joining functionality with additional edge cases, including empty path elements, excessive trailing slash trimming, custom URL scheme preservation, and IP address with port handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->