### PR TITLE
🧪 Add error path test for useUpdate outside provider

### DIFF
--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, mock, afterEach } from 'bun:test';
+
+// Must set __DEV__ before importing context.ts
+(globalThis as any).__DEV__ = true;
+
+const mockUseContext = mock(() => ({}));
+
+mock.module('react', () => {
+  return {
+    createContext: mock((defaultValue) => defaultValue),
+    useContext: mockUseContext,
+  };
+});
+
+// Import context after setting up mocks
+const { useUpdate } = await import('../context');
+const { default: i18n } = await import('../i18n');
+
+describe('context', () => {
+  afterEach(() => {
+    mockUseContext.mockClear();
+  });
+
+  test('useUpdate throws error when used outside UpdateProvider in __DEV__', () => {
+    mockUseContext.mockReturnValue({});
+
+    expect(() => useUpdate()).toThrow(i18n.t('error_use_update_outside_provider'));
+  });
+
+  test('useUpdate returns context when used inside UpdateProvider', () => {
+    const mockContext = { client: {} };
+    mockUseContext.mockReturnValue(mockContext);
+
+    expect(useUpdate()).toBe(mockContext as any);
+  });
+});

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test, mock, afterEach } from 'bun:test';
+import { describe, expect, test, mock, afterEach, afterAll } from 'bun:test';
 
 // Must set __DEV__ before importing context.ts
+const _origDEV = (globalThis as any).__DEV__;
 (globalThis as any).__DEV__ = true;
 
 const mockUseContext = mock(() => ({}));
@@ -17,6 +18,10 @@ const { useUpdate } = await import('../context');
 const { default: i18n } = await import('../i18n');
 
 describe('context', () => {
+  afterAll(() => {
+    (globalThis as any).__DEV__ = _origDEV;
+  });
+
   afterEach(() => {
     mockUseContext.mockClear();
   });


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap by adding a unit test for the `useUpdate` custom hook when it is called outside of the `UpdateProvider`.
📊 **Coverage:** The new test suite in `src/__tests__/context.test.ts` covers the error path where `context.client` is missing (i.e. outside the provider) to ensure the `error_use_update_outside_provider` error is correctly thrown, and also covers the success path inside the provider.
✨ **Result:** Increased test coverage and improved reliability of the React Context implementation, ensuring developers are properly notified when the hook is used incorrectly in development.

---
*PR created automatically by Jules for task [1711551568244178397](https://jules.google.com/task/1711551568244178397) started by @sunnylqm*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for context module behavior, validating that using the update helper fails with a clear error when no provider is present and succeeds when a provider is available.
  * Ensures test environment state and mocks are properly restored between and after tests to avoid cross-test leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->