### PR TITLE
🧹 Remove deprecated PushyProvider

### DIFF
--- a/Example/expoUsePushy/App.tsx
+++ b/Example/expoUsePushy/App.tsx
@@ -6,7 +6,7 @@ import {StyleSheet, Text, View, TouchableOpacity, Image} from 'react-native';
 import TestConsole from './TestConsole';
 
 import _updateConfig from './update.json';
-import {PushyProvider, Pushy, usePushy} from 'react-native-update';
+import { UpdateProvider, Pushy, usePushy} from 'react-native-update';
 const {appKey} = _updateConfig.android;
 
 function Home() {
@@ -214,8 +214,8 @@ const pushyClient = new Pushy({
 
 export default function HomeScreen() {
   return (
-    <PushyProvider client={pushyClient}>
+    <UpdateProvider client={pushyClient}>
       <Home />
-    </PushyProvider>
+    </UpdateProvider>
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Pushy, Cresc } from './client';
 export { UpdateContext, usePushy, useUpdate } from './context';
-export { PushyProvider, UpdateProvider } from './provider';
+export { UpdateProvider } from './provider';
 export { PushyModule, UpdateModule } from './core';

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -421,5 +421,3 @@ export const UpdateProvider = ({
   );
 };
 
-/** @deprecated Please use `UpdateProvider` instead */
-export const PushyProvider = UpdateProvider;


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `PushyProvider` component, its re-export in `src/index.ts`, and updated its usage in `Example/expoUsePushy/App.tsx` to use `UpdateProvider`.
💡 **Why:** `PushyProvider` was marked as deprecated with instructions to use `UpdateProvider` instead. Removing it improves codebase maintainability and readability by eliminating dead/deprecated code.
✅ **Verification:** Verified by running the test suite (`bun test src/`) and ensuring all tests pass without any type or execution errors.
✨ **Result:** A cleaner codebase with the deprecated component safely removed.

---
*PR created automatically by Jules for task [7122732357880338343](https://jules.google.com/task/7122732357880338343) started by @sunnylqm*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `PushyProvider` has been removed from the library. Use `UpdateProvider` as a replacement in your code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->