### PR TITLE
fix(harmony): align isFirstTime and rollback mechanism with android/ios

### DIFF
--- a/harmony/pushy/src/main/ets/PushyTurboModule.ts
+++ b/harmony/pushy/src/main/ets/PushyTurboModule.ts
@@ -75,7 +75,7 @@ export class PushyTurboModule extends UITurboModule {
     const currentVersionInfo = currentVersion
       ? this.context.getKv(`hash_${currentVersion}`)
       : '';
-    const isFirstTime = this.context.isFirstTime();
+    const isFirstTime = this.context.consumeFirstLoadMarker();
     const rolledBackVersion = this.context.rolledBackVersion();
     const uuid = this.context.getKv('uuid');
     const isUsingBundleUrl = this.context.getIsUsingBundleUrl();

--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -281,6 +281,8 @@ export class UpdateContext {
 
   public clearFirstTime(): void {
     this.runStateOperation(STATE_OP_CLEAR_FIRST_TIME, '', { cleanUp: true });
+    this.preferences.deleteSync('firstLoadMarked');
+    this.flushPreferences('clear first time');
   }
 
   public clearRollbackMark(): void {
@@ -373,7 +375,8 @@ export class UpdateContext {
   public consumeFirstLoadMarker(): boolean {
     const marked = this.readString('firstLoadMarked') === 'true';
     if (marked) {
-      this.setKv('firstLoadMarked', 'false');
+      this.preferences.deleteSync('firstLoadMarked');
+      this.flushPreferences('clear first load marker');
     }
     return marked;
   }

--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -25,6 +25,7 @@ export class UpdateContext {
   private preferences!: preferences.Preferences;
   private static DEBUG: boolean = false;
   private static isUsingBundleUrl: boolean = false;
+  private static ignoreRollback: boolean = false;
 
   constructor(context: common.UIAbilityContext) {
     this.context = context;
@@ -245,6 +246,7 @@ export class UpdateContext {
       return;
     }
 
+    UpdateContext.ignoreRollback = false;
     this.cleanUp();
     this.persistState(nextState, { clearExisting: true });
   }
@@ -361,10 +363,19 @@ export class UpdateContext {
       }
 
       this.runStateOperation(STATE_OP_SWITCH_VERSION, hash);
+      UpdateContext.ignoreRollback = false;
     } catch (e) {
       console.error('Failed to switch version:', e);
       throw e;
     }
+  }
+
+  public consumeFirstLoadMarker(): boolean {
+    const marked = this.readString('firstLoadMarked') === 'true';
+    if (marked) {
+      this.setKv('firstLoadMarked', 'false');
+    }
+    return marked;
   }
 
   public getBundleUrl() {
@@ -373,11 +384,17 @@ export class UpdateContext {
       STATE_OP_RESOLVE_LAUNCH,
       this.getStateSnapshot(),
       '',
-      false,
-      false,
+      UpdateContext.ignoreRollback,
+      true,
     );
     if (launchState.didRollback || launchState.consumedFirstTime) {
       this.persistState(launchState);
+      if (launchState.consumedFirstTime) {
+        this.setKv('firstLoadMarked', 'true');
+      }
+    }
+    if (launchState.consumedFirstTime) {
+      UpdateContext.ignoreRollback = true;
     }
 
     let version = launchState.loadVersion || '';

--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -73,9 +73,8 @@ export class UpdateContext {
 
   public getBuildTime(): string {
     try {
-      const content = this.context.resourceManager.getRawFileContentSync(
-        'meta.json',
-      );
+      const content =
+        this.context.resourceManager.getRawFileContentSync('meta.json');
       const metaData = JSON.parse(
         new util.TextDecoder().decodeToString(content),
       ) as Record<string, string | number | boolean | null | undefined>;
@@ -183,6 +182,8 @@ export class UpdateContext {
       clearExisting?: boolean;
       removeStaleHash?: boolean;
       cleanUp?: boolean;
+      markFirstLoadMarker?: boolean;
+      clearFirstLoadMarker?: boolean;
     } = {},
   ): void {
     if (options.clearExisting) {
@@ -191,6 +192,12 @@ export class UpdateContext {
     this.applyState(state);
     if (options.removeStaleHash && state.staleVersionToDelete) {
       this.preferences.deleteSync(`hash_${state.staleVersionToDelete}`);
+    }
+    if (options.markFirstLoadMarker) {
+      this.preferences.putSync('firstLoadMarked', 'true');
+    }
+    if (options.clearFirstLoadMarker) {
+      this.preferences.deleteSync('firstLoadMarked');
     }
     this.flushPreferences('persist state');
     if (options.cleanUp) {
@@ -204,6 +211,7 @@ export class UpdateContext {
     options: {
       removeStaleHash?: boolean;
       cleanUp?: boolean;
+      clearFirstLoadMarker?: boolean;
     } = {},
   ): StateCoreResult {
     const nextState = NativePatchCore.runStateCore(
@@ -280,9 +288,10 @@ export class UpdateContext {
   }
 
   public clearFirstTime(): void {
-    this.runStateOperation(STATE_OP_CLEAR_FIRST_TIME, '', { cleanUp: true });
-    this.preferences.deleteSync('firstLoadMarked');
-    this.flushPreferences('clear first time');
+    this.runStateOperation(STATE_OP_CLEAR_FIRST_TIME, '', {
+      cleanUp: true,
+      clearFirstLoadMarker: true,
+    });
   }
 
   public clearRollbackMark(): void {
@@ -391,10 +400,9 @@ export class UpdateContext {
       true,
     );
     if (launchState.didRollback || launchState.consumedFirstTime) {
-      this.persistState(launchState);
-      if (launchState.consumedFirstTime) {
-        this.setKv('firstLoadMarked', 'true');
-      }
+      this.persistState(launchState, {
+        markFirstLoadMarker: launchState.consumedFirstTime,
+      });
     }
     if (launchState.consumedFirstTime) {
       UpdateContext.ignoreRollback = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved first-launch handling by atomically checking and consuming the stored “first load” marker, ensuring it’s cleared reliably.
  * Updated startup state resolution to better reflect rollback outcomes and preserve the correct launch state.
  * Fixed a scenario where rollback-related handling could remain enabled after successful version switches or state synchronization.
  * Refined how first-launch status is exposed during initialization so the framework receives the correct value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->