### PR TITLE
fix(harmony): align isFirstTime, rollback, and soft reload with android/ios

### DIFF
--- a/harmony/pushy/src/main/ets/PushyFileJSBundleProvider.ets
+++ b/harmony/pushy/src/main/ets/PushyFileJSBundleProvider.ets
@@ -9,36 +9,35 @@ import { UpdateContext } from './UpdateContext';
 
 export class PushyFileJSBundleProvider extends JSBundleProvider {
   private updateContext: UpdateContext;
-  private path: string = '';
 
   constructor(context: common.UIAbilityContext) {
     super();
     this.updateContext = new UpdateContext(context);
-    this.path = this.updateContext.getBundleUrl();
   }
 
   getURL(): string {
-    return this.path;
+    return this.updateContext.getBundleUrl();
   }
 
   async getBundle(): Promise<FileJSBundle> {
-    if (!this.path) {
+    const path = this.updateContext.getBundleUrl();
+    if (!path) {
       throw new JSBundleProviderError({
         whatHappened: 'No pushy bundle found. using default bundle',
         howCanItBeFixed: [''],
       });
     }
     try {
-      await fs.access(this.path, fs.OpenMode.READ_ONLY);
+      await fs.access(path, fs.OpenMode.READ_ONLY);
       return {
-        filePath: this.path,
+        filePath: path,
       };
     } catch (error) {
       throw new JSBundleProviderError({
-        whatHappened: `Couldn't load JSBundle from ${this.path}`,
+        whatHappened: `Couldn't load JSBundle from ${path}`,
         extraData: error,
         howCanItBeFixed: [
-          `Check if a bundle exists at "${this.path}" on your device.`,
+          `Check if a bundle exists at "${path}" on your device.`,
         ],
       });
     }

--- a/harmony/pushy/src/main/ets/PushyTurboModule.ts
+++ b/harmony/pushy/src/main/ets/PushyTurboModule.ts
@@ -65,6 +65,17 @@ export class PushyTurboModule extends UITurboModule {
     await this.mUiCtx.startAbility(want);
   }
 
+  private async reloadBridge(): Promise<void> {
+    const devToolsController = (this.ctx as Record<string, any>).devToolsController;
+    if (devToolsController) {
+      logger.debug(TAG, 'reloadBridge via devToolsController RELOAD');
+      devToolsController.eventEmitter.emit("RELOAD", { reason: 'HotReload2' });
+    } else {
+      logger.debug(TAG, 'reloadBridge via restartAbility');
+      await this.restartAbility();
+    }
+  }
+
   getConstants(): Object {
     logger.debug(TAG, ',call getConstants');
     const packageVersion = this.context.getPackageVersion();
@@ -121,7 +132,7 @@ export class PushyTurboModule extends UITurboModule {
 
     try {
       this.context.switchVersion(hash);
-      await this.restartAbility();
+      await this.reloadBridge();
     } catch (error) {
       logger.error(TAG, `reloadUpdate failed: ${getErrorMessage(error)}`);
       throw Error(`switchVersion failed ${getErrorMessage(error)}`);
@@ -131,7 +142,7 @@ export class PushyTurboModule extends UITurboModule {
   async restartApp(): Promise<void> {
     logger.debug(TAG, ',call restartApp');
     try {
-      await this.restartAbility();
+      await this.reloadBridge();
     } catch (error) {
       logger.error(TAG, `restartApp failed: ${getErrorMessage(error)}`);
       throw Error(`restartApp failed ${getErrorMessage(error)}`);

--- a/harmony/pushy/src/main/ets/PushyTurboModule.ts
+++ b/harmony/pushy/src/main/ets/PushyTurboModule.ts
@@ -75,7 +75,7 @@ export class PushyTurboModule extends UITurboModule {
     const currentVersionInfo = currentVersion
       ? this.context.getKv(`hash_${currentVersion}`)
       : '';
-    const isFirstTime = this.context.isFirstTime();
+    const isFirstTime = this.context.consumeFirstLoadMarker();
     const rolledBackVersion = this.context.rolledBackVersion();
     const uuid = this.context.getKv('uuid');
     const isUsingBundleUrl = this.context.getIsUsingBundleUrl();

--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -281,6 +281,8 @@ export class UpdateContext {
 
   public clearFirstTime(): void {
     this.runStateOperation(STATE_OP_CLEAR_FIRST_TIME, '', { cleanUp: true });
+    this.preferences.deleteSync('firstLoadMarked');
+    this.flushPreferences('clear first time');
   }
 
   public clearRollbackMark(): void {
@@ -373,7 +375,8 @@ export class UpdateContext {
   public consumeFirstLoadMarker(): boolean {
     const marked = this.readString('firstLoadMarked') === 'true';
     if (marked) {
-      this.setKv('firstLoadMarked', 'false');
+      this.preferences.deleteSync('firstLoadMarked');
+      this.flushPreferences('clear first load marker');
     }
     return marked;
   }

--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -25,6 +25,7 @@ export class UpdateContext {
   private preferences!: preferences.Preferences;
   private static DEBUG: boolean = false;
   private static isUsingBundleUrl: boolean = false;
+  private static ignoreRollback: boolean = false;
 
   constructor(context: common.UIAbilityContext) {
     this.context = context;
@@ -245,6 +246,7 @@ export class UpdateContext {
       return;
     }
 
+    UpdateContext.ignoreRollback = false;
     this.cleanUp();
     this.persistState(nextState, { clearExisting: true });
   }
@@ -361,10 +363,19 @@ export class UpdateContext {
       }
 
       this.runStateOperation(STATE_OP_SWITCH_VERSION, hash);
+      UpdateContext.ignoreRollback = false;
     } catch (e) {
       console.error('Failed to switch version:', e);
       throw e;
     }
+  }
+
+  public consumeFirstLoadMarker(): boolean {
+    const marked = this.readString('firstLoadMarked') === 'true';
+    if (marked) {
+      this.setKv('firstLoadMarked', 'false');
+    }
+    return marked;
   }
 
   public getBundleUrl() {
@@ -373,11 +384,17 @@ export class UpdateContext {
       STATE_OP_RESOLVE_LAUNCH,
       this.getStateSnapshot(),
       '',
-      false,
-      false,
+      UpdateContext.ignoreRollback,
+      true,
     );
     if (launchState.didRollback || launchState.consumedFirstTime) {
       this.persistState(launchState);
+      if (launchState.consumedFirstTime) {
+        this.setKv('firstLoadMarked', 'true');
+      }
+    }
+    if (launchState.consumedFirstTime) {
+      UpdateContext.ignoreRollback = true;
     }
 
     let version = launchState.loadVersion || '';

--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -73,9 +73,8 @@ export class UpdateContext {
 
   public getBuildTime(): string {
     try {
-      const content = this.context.resourceManager.getRawFileContentSync(
-        'meta.json',
-      );
+      const content =
+        this.context.resourceManager.getRawFileContentSync('meta.json');
       const metaData = JSON.parse(
         new util.TextDecoder().decodeToString(content),
       ) as Record<string, string | number | boolean | null | undefined>;
@@ -183,6 +182,8 @@ export class UpdateContext {
       clearExisting?: boolean;
       removeStaleHash?: boolean;
       cleanUp?: boolean;
+      markFirstLoadMarker?: boolean;
+      clearFirstLoadMarker?: boolean;
     } = {},
   ): void {
     if (options.clearExisting) {
@@ -191,6 +192,12 @@ export class UpdateContext {
     this.applyState(state);
     if (options.removeStaleHash && state.staleVersionToDelete) {
       this.preferences.deleteSync(`hash_${state.staleVersionToDelete}`);
+    }
+    if (options.markFirstLoadMarker) {
+      this.preferences.putSync('firstLoadMarked', 'true');
+    }
+    if (options.clearFirstLoadMarker) {
+      this.preferences.deleteSync('firstLoadMarked');
     }
     this.flushPreferences('persist state');
     if (options.cleanUp) {
@@ -204,6 +211,7 @@ export class UpdateContext {
     options: {
       removeStaleHash?: boolean;
       cleanUp?: boolean;
+      clearFirstLoadMarker?: boolean;
     } = {},
   ): StateCoreResult {
     const nextState = NativePatchCore.runStateCore(
@@ -280,9 +288,10 @@ export class UpdateContext {
   }
 
   public clearFirstTime(): void {
-    this.runStateOperation(STATE_OP_CLEAR_FIRST_TIME, '', { cleanUp: true });
-    this.preferences.deleteSync('firstLoadMarked');
-    this.flushPreferences('clear first time');
+    this.runStateOperation(STATE_OP_CLEAR_FIRST_TIME, '', {
+      cleanUp: true,
+      clearFirstLoadMarker: true,
+    });
   }
 
   public clearRollbackMark(): void {
@@ -391,10 +400,9 @@ export class UpdateContext {
       true,
     );
     if (launchState.didRollback || launchState.consumedFirstTime) {
-      this.persistState(launchState);
-      if (launchState.consumedFirstTime) {
-        this.setKv('firstLoadMarked', 'true');
-      }
+      this.persistState(launchState, {
+        markFirstLoadMarker: launchState.consumedFirstTime,
+      });
     }
     if (launchState.consumedFirstTime) {
       UpdateContext.ignoreRollback = true;


### PR DESCRIPTION
This PR resolves critical design discrepancies in the HarmonyOS implementation, aligning it with the robust state-machine logic and reload experiences of the iOS and Android platforms:

### 1. isFirstTime Loading & Rollback Protection
- **Problem**: The HarmonyOS module read the raw `firstTime` value from preferences directly on React Native startup without ever consuming or resetting it. Furthermore, the `consume_first_time_on_launch` parameter was hardcoded to `false`. This prevented rollback protection from triggering on crash/failure, and prevented `isFirstTime` from being a single-use flag.
- **Solution**:
  - Set `consume_first_time_on_launch = true` during `getBundleUrl()`.
  - Introduced a persistent `firstLoadMarked` key to Preferences when the launch state consumes first time.
  - Implemented `consumeFirstLoadMarker()` to read and immediately delete the persistent marker.
  - Aligned `clearFirstTime()` to delete `firstLoadMarked`.
  - Introduced `ignoreRollback` as a static memory variable to handle multiple bundle path resolutions during a single application process startup.

### 2. In-Memory Soft Reload
- **Problem**: Previously, reload operations on HarmonyOS triggered a hard application UIAbility restart (`terminateSelf` + `startAbility`), causing the window to blink/go white. Both Android and iOS support smooth in-memory soft reloading.
- **Solution**:
  - Implemented `reloadBridge()` to emit the `"RELOAD"` event to RNOH's `devToolsController` for seamless in-memory reloading.
  - Added a fallback to `restartAbility()` if `devToolsController` is unavailable.
  - Updated `PushyFileJSBundleProvider.ets` to dynamically fetch the update bundle URL on every call to `getURL()` / `getBundle()`, ensuring that when the React Native container reloads, it fetches the newly switched version.

All JS/TS unit tests pass (70/70) and the Harmony HAR compiled successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved app update handling so reloads can refresh the app more reliably, with a smoother fallback when a live reload isn’t available.

* **Bug Fixes**
  * Fixed bundle loading to use the latest available app package path, reducing errors after updates.
  * Improved first-launch behavior so the app better distinguishes an initial run from later launches during update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->