### PR TITLE
feat(harmony): implement in-memory soft reload using devToolsController RELOAD

### DIFF
--- a/harmony/pushy/src/main/ets/PushyFileJSBundleProvider.ets
+++ b/harmony/pushy/src/main/ets/PushyFileJSBundleProvider.ets
@@ -9,36 +9,35 @@ import { UpdateContext } from './UpdateContext';
 
 export class PushyFileJSBundleProvider extends JSBundleProvider {
   private updateContext: UpdateContext;
-  private path: string = '';
 
   constructor(context: common.UIAbilityContext) {
     super();
     this.updateContext = new UpdateContext(context);
-    this.path = this.updateContext.getBundleUrl();
   }
 
   getURL(): string {
-    return this.path;
+    return this.updateContext.getBundleUrl();
   }
 
   async getBundle(): Promise<FileJSBundle> {
-    if (!this.path) {
+    const path = this.updateContext.getBundleUrl();
+    if (!path) {
       throw new JSBundleProviderError({
         whatHappened: 'No pushy bundle found. using default bundle',
         howCanItBeFixed: [''],
       });
     }
     try {
-      await fs.access(this.path, fs.OpenMode.READ_ONLY);
+      await fs.access(path, fs.OpenMode.READ_ONLY);
       return {
-        filePath: this.path,
+        filePath: path,
       };
     } catch (error) {
       throw new JSBundleProviderError({
-        whatHappened: `Couldn't load JSBundle from ${this.path}`,
+        whatHappened: `Couldn't load JSBundle from ${path}`,
         extraData: error,
         howCanItBeFixed: [
-          `Check if a bundle exists at "${this.path}" on your device.`,
+          `Check if a bundle exists at "${path}" on your device.`,
         ],
       });
     }

--- a/harmony/pushy/src/main/ets/PushyTurboModule.ts
+++ b/harmony/pushy/src/main/ets/PushyTurboModule.ts
@@ -65,6 +65,17 @@ export class PushyTurboModule extends UITurboModule {
     await this.mUiCtx.startAbility(want);
   }
 
+  private async reloadBridge(): Promise<void> {
+    const devToolsController = (this.ctx as Record<string, any>).devToolsController;
+    if (devToolsController) {
+      logger.debug(TAG, 'reloadBridge via devToolsController RELOAD');
+      devToolsController.eventEmitter.emit("RELOAD", { reason: 'HotReload2' });
+    } else {
+      logger.debug(TAG, 'reloadBridge via restartAbility');
+      await this.restartAbility();
+    }
+  }
+
   getConstants(): Object {
     logger.debug(TAG, ',call getConstants');
     const packageVersion = this.context.getPackageVersion();
@@ -121,7 +132,7 @@ export class PushyTurboModule extends UITurboModule {
 
     try {
       this.context.switchVersion(hash);
-      await this.restartAbility();
+      await this.reloadBridge();
     } catch (error) {
       logger.error(TAG, `reloadUpdate failed: ${getErrorMessage(error)}`);
       throw Error(`switchVersion failed ${getErrorMessage(error)}`);
@@ -131,7 +142,7 @@ export class PushyTurboModule extends UITurboModule {
   async restartApp(): Promise<void> {
     logger.debug(TAG, ',call restartApp');
     try {
-      await this.restartAbility();
+      await this.reloadBridge();
     } catch (error) {
       logger.error(TAG, `restartApp failed: ${getErrorMessage(error)}`);
       throw Error(`restartApp failed ${getErrorMessage(error)}`);


### PR DESCRIPTION
This PR aligns the HarmonyOS reload behavior with iOS/Android by implementing an in-memory soft-reload mechanism:

### Changes:
- **PushyFileJSBundleProvider**: Modified to dynamically fetch the update bundle URL path on every query. This allows RNOH to load the newly selected update version when reloaded.
- **PushyTurboModule**: Implemented `reloadBridge()` which emits the `"RELOAD"` event on RNOH's `devToolsController` for a seamless, in-memory refresh (no window blinking). Falls back to the hard restart of the Ability if DevTools is unavailable.
- Updated `reloadUpdate()` and `restartApp()` to invoke `reloadBridge()`.

Unit tests pass and HAR compiles successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App reloads now prefer a faster hot-reload path when available, improving update responsiveness.

* **Bug Fixes**
  * Bundle loading now uses the latest bundle location at runtime instead of a potentially stale cached value.
  * Reload and restart actions continue to fall back to the standard app restart flow if hot-reload isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->