### PR TITLE
fix(harmony): safeguard binary version sync against background-thread resource loading failures

### DIFF
--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -26,6 +26,8 @@ export class UpdateContext {
   private static DEBUG: boolean = false;
   private static isUsingBundleUrl: boolean = false;
   private static ignoreRollback: boolean = false;
+  private static cachedPackageVersion: string = '';
+  private static cachedBuildTime: string = '';
 
   constructor(context: common.UIAbilityContext) {
     this.context = context;
@@ -60,11 +62,15 @@ export class UpdateContext {
   }
 
   public getPackageVersion(): string {
+    if (UpdateContext.cachedPackageVersion) {
+      return UpdateContext.cachedPackageVersion;
+    }
     try {
       const bundleInfo = bundleManager.getBundleInfoForSelfSync(
         this.getBundleFlags(),
       );
-      return bundleInfo?.versionName || 'Unknown';
+      UpdateContext.cachedPackageVersion = bundleInfo?.versionName || 'Unknown';
+      return UpdateContext.cachedPackageVersion;
     } catch (error) {
       console.error('Failed to get bundle info:', error);
       return '';
@@ -72,6 +78,9 @@ export class UpdateContext {
   }
 
   public getBuildTime(): string {
+    if (UpdateContext.cachedBuildTime) {
+      return UpdateContext.cachedBuildTime;
+    }
     try {
       const content =
         this.context.resourceManager.getRawFileContentSync('meta.json');
@@ -79,9 +88,12 @@ export class UpdateContext {
         new util.TextDecoder().decodeToString(content),
       ) as Record<string, string | number | boolean | null | undefined>;
       if (metaData.pushy_build_time) {
-        return String(metaData.pushy_build_time);
+        UpdateContext.cachedBuildTime = String(metaData.pushy_build_time);
+        return UpdateContext.cachedBuildTime;
       }
-    } catch {}
+    } catch (error) {
+      console.error('Failed to read build time from raw file:', error);
+    }
     return '';
   }
 
@@ -244,6 +256,9 @@ export class UpdateContext {
     packageVersion: string,
     buildTime: string,
   ): void {
+    if (!packageVersion || !buildTime) {
+      return;
+    }
     const currentState = this.getStateSnapshot();
     const nextState = NativePatchCore.syncStateWithBinaryVersion(
       packageVersion,


### PR DESCRIPTION
This PR implements a safety guard and caching layer for binary version synchronization to prevent update state wipes during soft reloads:

### Background & Issue
During a soft reload, the React Native container initializes its TurboModules (including `Pushy`) on a background JS thread. The `UpdateContext` constructor calls `syncStateWithBinaryVersion()` which tries to read `meta.json` synchronously via `resourceManager.getRawFileContentSync('meta.json')`.
In HarmonyOS, synchronous resource manager APIs are not thread-safe and throw exceptions if called from non-UI threads. The exception is silently caught, returning an empty string `""`. Because this empty string doesn't match the previously stored build time, the system assumes the binary has been updated and clears the entire update Preferences.

### Solution
1. **Safety Guard**: Added a check at the top of `syncStateWithBinaryVersion()`:
   ```typescript
   if (!packageVersion || !buildTime) {
     return;
   }
   ```
   If the current version/build time cannot be read (e.g. background thread loading failures), it immediately returns early instead of triggering a false-positive mismatch and wiping preferences.
2. **Static Memory Cache**: Retained the caching of `packageVersion` and `buildTime` inside static class fields during the first resolution (which always runs on the Main/UI thread in the bundle provider).

Unit tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version and build-time handling so the app now reuses cached values when available.
  * Prevented state sync from running when required version information is missing.
  * Added clearer error logging for version and build-time lookup issues, helping diagnose failures more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->