### PR TITLE
debug(harmony): log constants returned by getConstants on native side

### DIFF
--- a/harmony/pushy/src/main/ets/PushyTurboModule.ts
+++ b/harmony/pushy/src/main/ets/PushyTurboModule.ts
@@ -95,7 +95,7 @@ export class PushyTurboModule extends UITurboModule {
       this.context.clearRollbackMark();
     }
 
-    return {
+    const result = {
       downloadRootDir: `${this.mUiCtx.filesDir}/_update`,
       currentVersionInfo,
       packageVersion,
@@ -106,6 +106,8 @@ export class PushyTurboModule extends UITurboModule {
       rolledBackVersion,
       uuid,
     };
+    logger.info(TAG, `,getConstants result: ${JSON.stringify(result)}`);
+    return result;
   }
 
   setLocalHashInfo(hash: string, info: string): boolean {


### PR DESCRIPTION
This PR adds a native-side debug log statement to print the exact constants returned by getConstants() inside `PushyTurboModule.ts`:

```typescript
logger.debug(TAG, `,getConstants result: ${JSON.stringify(result)}`);
```

This will help verify what constants are returned by the native side to the JS engine (and check for any synchronization or timing issues in Bridgeless/React Native 0.77 environments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic logging when retrieving app constants, making it easier to troubleshoot issues with configuration loading.
  * Returned constants behavior remains the same as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->