### PR TITLE
fix(harmony): widen rnoh dependency range to support both 0.72 and 0.77+

### DIFF
--- a/harmony/pushy/oh-package.json5
+++ b/harmony/pushy/oh-package.json5
@@ -9,7 +9,7 @@
   main: 'index.ets',
   version: '10.35.1',
   dependencies: {
-    '@rnoh/react-native-openharmony': '^0.72.96',
+    '@rnoh/react-native-openharmony': '>=0.72.96',
   },
   modelVersion: '5.0.0',
 }


### PR DESCRIPTION
This PR updates `oh-package.json5` dependency for `@rnoh/react-native-openharmony` from `^0.72.96` to `>=0.72.96` to allow users of React Native OpenHarmony 0.77+ to install the library without peer dependency conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened the supported version range for an app package, allowing compatibility with newer releases without requiring a specific pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->