### PR TITLE
fix(harmony): prepend file:// scheme to getURL() to enable local image loading from hot update bundle

### DIFF
--- a/harmony/pushy/src/main/ets/PushyFileJSBundleProvider.ets
+++ b/harmony/pushy/src/main/ets/PushyFileJSBundleProvider.ets
@@ -16,7 +16,11 @@ export class PushyFileJSBundleProvider extends JSBundleProvider {
   }
 
   getURL(): string {
-    return this.updateContext.getBundleUrl();
+    const path = this.updateContext.getBundleUrl();
+    if (path && !path.startsWith('file://')) {
+      return 'file://' + path;
+    }
+    return path;
   }
 
   async getBundle(): Promise<FileJSBundle> {


### PR DESCRIPTION
This PR fixes local image assets (imported via `require('./image.png')`) not displaying when loaded from a hot-updated bundle on React Native OpenHarmony.

### Root Cause
1. In React Native's `AssetSourceResolver.harmony.ts`, local assets resolve relative to the bundle URL if and only if the bundle URL starts with the `file://` scheme.
2. Previously, `PushyFileJSBundleProvider.ets`'s `getURL()` returned the raw absolute path (`/data/storage/.../bundle.harmony.js`) without the `file://` prefix.
3. This caused `AssetSourceResolver` to resolve the asset's URI as `asset://assets/.../image.png`, which ArkUI's `RNImage.ets` compiles into a compile-time `$rawfile(...)` macro. Since hot-updated assets reside in the sandbox at runtime, this lookup failed, resulting in blank/invisible images.
4. Prepending `file://` to `getURL()` causes `AssetSourceResolver` to resolve local assets as `file:///data/storage/.../assets/image.png`, which ArkUI's `Image()` component can load directly from the device's sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bundle URL handling so file paths are consistently returned with the correct `file://` format.
  * Fixed cases where non-`file://` paths could be returned without normalization, helping ensure more reliable app loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->