### PR TITLE
feat: optimize cleanup logic and fix static resource bloat & fd leaks

### DIFF
--- a/android/src/main/java/cn/reactnative/modules/update/DownloadTask.java
+++ b/android/src/main/java/cn/reactnative/modules/update/DownloadTask.java
@@ -258,6 +258,9 @@ class DownloadTask implements Runnable {
             }
         }
 
+        if (params.targetFile.exists()) {
+            params.targetFile.delete();
+        }
     }
 
     private void doPatchFromApk() throws IOException, JSONException {
@@ -300,6 +303,9 @@ class DownloadTask implements Runnable {
         }
 
         bundledResourceCopier.copyFromResource(copyList, contents.copyCrcs);
+        if (params.targetFile.exists()) {
+            params.targetFile.delete();
+        }
     }
 
     private void doPatchFromPpk() throws IOException, JSONException {
@@ -326,7 +332,9 @@ class DownloadTask implements Runnable {
             contents.copyTos.toArray(new String[0]),
             contents.deletes.toArray(new String[0])
         );
-
+        if (params.targetFile.exists()) {
+            params.targetFile.delete();
+        }
     }
 
     private void doCleanUp() {
@@ -334,7 +342,7 @@ class DownloadTask implements Runnable {
             params.unzipDirectory.getAbsolutePath(),
             params.hash,
             params.originHash,
-            7
+            3
         );
     }
 

--- a/harmony/pushy/src/main/ets/DownloadTask.ts
+++ b/harmony/pushy/src/main/ets/DownloadTask.ts
@@ -442,6 +442,13 @@ export class DownloadTask {
     await this.downloadFile(params);
     await this.recreateDirectory(params.unzipDirectory);
     await zlib.decompressFile(params.targetFile, params.unzipDirectory);
+    try {
+      if (fileIo.accessSync(params.targetFile)) {
+        await fileIo.unlink(params.targetFile);
+      }
+    } catch (e) {
+      console.error('Failed to delete temporary zip file after decompression:', e);
+    }
   }
 
   private async doPatchFromApp(params: DownloadTaskParams): Promise<void> {
@@ -484,6 +491,13 @@ export class DownloadTask {
       ),
       params.unzipDirectory,
     );
+    try {
+      if (fileIo.accessSync(params.targetFile)) {
+        await fileIo.unlink(params.targetFile);
+      }
+    } catch (e) {
+      console.error('Failed to delete temporary zip file after patching:', e);
+    }
   }
 
   private async doPatchFromPpk(params: DownloadTaskParams): Promise<void> {
@@ -517,6 +531,13 @@ export class DownloadTask {
       enableMerge: plan.enableMerge,
     });
     console.info('Patch from PPK completed');
+    try {
+      if (fileIo.accessSync(params.targetFile)) {
+        await fileIo.unlink(params.targetFile);
+      }
+    } catch (e) {
+      console.error('Failed to delete temporary patch file after patching:', e);
+    }
   }
 
   private async copyFromResource(
@@ -548,27 +569,35 @@ export class DownloadTask {
             parentDirs.map(dir => this.ensureDirectory(dir)),
           );
           await Promise.all(
-            targets.map(target => this.writeFileContent(target, mediaBuffer.buffer)),
+            targets.map(target => this.writeFileContent(target, mediaBuffer)),
           );
           continue;
         }
         const fromContent = await resourceManager.getRawFd(currentFrom);
-        const [firstTarget, ...restTargets] = targets;
-        const parentDirs = [
-          ...new Set(
-            targets.map(t => t.substring(0, t.lastIndexOf('/'))).filter(Boolean),
-          ),
-        ];
-        await Promise.all(
-          parentDirs.map(dir => this.ensureDirectory(dir))
-        );
-        if (fileIo.accessSync(firstTarget)) {
-          await fileIo.unlink(firstTarget);
+        try {
+          const [firstTarget, ...restTargets] = targets;
+          const parentDirs = [
+            ...new Set(
+              targets.map(t => t.substring(0, t.lastIndexOf('/'))).filter(Boolean),
+            ),
+          ];
+          await Promise.all(
+            parentDirs.map(dir => this.ensureDirectory(dir))
+          );
+          if (fileIo.accessSync(firstTarget)) {
+            await fileIo.unlink(firstTarget);
+          }
+          saveFileToSandbox(fromContent, firstTarget);
+          await Promise.all(
+            restTargets.map(target => this.copySandboxFile(firstTarget, target)),
+          );
+        } finally {
+          try {
+            await resourceManager.closeRawFd(currentFrom);
+          } catch (closeError) {
+            console.error(`Failed to close raw fd for ${currentFrom}:`, closeError);
+          }
         }
-        saveFileToSandbox(fromContent, firstTarget);
-        await Promise.all(
-          restTargets.map(target => this.copySandboxFile(firstTarget, target)),
-        );
       }
     } catch (error) {
       error.message =
@@ -589,7 +618,7 @@ export class DownloadTask {
         params.unzipDirectory,
         params.hash || '',
         params.originHash || '',
-        7,
+        3,
       );
     } catch (error) {
       error.message = 'Cleanup failed:' + error.message;

--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -513,7 +513,7 @@ export class UpdateContext {
       this.rootDir,
       state.currentVersion || '',
       state.lastVersion || '',
-      7,
+      3,
     );
   }
 

--- a/ios/RCTPushy/RCTPushy.mm
+++ b/ios/RCTPushy/RCTPushy.mm
@@ -748,7 +748,7 @@ RCT_EXPORT_METHOD(markSuccess:(RCTPromiseResolveBlock)resolve
             PushyToStdString(downloadDir),
             state.current_version,
             state.last_version,
-            7
+            3
         );
         if (!status.ok) {
             RCTLogWarn(@"Pushy cleanup error: %s", status.message.c_str());


### PR DESCRIPTION
This PR optimizes the hot update cleanup logic and fixes critical resource copying bugs on HarmonyOS:

### Changes
1. **Fix Static Resource Bloat (HarmonyOS)**: Passed the  view (`mediaBuffer`) instead of the underlying `ArrayBuffer` (`mediaBuffer.buffer`) when writing media resources. This prevents writing excessive raw buffer bytes to the sandbox files.
2. **Fix FD Leak (HarmonyOS)**: Wrapped the raw FD acquisition/resource copy inside a `try...finally` block to ensure `resourceManager.closeRawFd` is always called to release file descriptors.
3. **Optimize Old Version Clean Up (All Platforms)**: Reduced the retention period for obsolete hot-update version directories from 7 days to 3 days across Android, iOS, and HarmonyOS.
4. **Delete Downloaded Archive Immediately (Android)**: Aligned Android with iOS/HarmonyOS by deleting downloaded `.ppk`/`.patch` files immediately after successful decompression/patching rather than waiting for the old package clean-up job.

All core unit tests and lints pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after update downloads and patch application, reducing leftover temporary archive files.
  * Made file cleanup more resilient so cleanup issues won’t interrupt the update process.
  * Updated retention handling so older update files are cleared more aggressively, helping keep storage usage lower.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->