### PR TITLE
fix: ignore bun and ohpm caches in npmignore and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ Example/harmony_use_pushy/harmony/entry/src/main/cpp/generated
 Example/testHotUpdate/.e2e-artifacts
 harmony/pushy/src/main/cpp/android-generated
 **/ios/.xcode.env.local
+.bun-cache
+.ohpm-cache

--- a/.npmignore
+++ b/.npmignore
@@ -66,6 +66,10 @@ harmony/**
 
 .tmp
 .cursor
+.e2e-rn077-oldarch
+.claude
+.bun-cache
+.ohpm-cache
 
 android/jni/lzma/bin
 android/jni/lzma/DOC


### PR DESCRIPTION
This PR ignores the .bun-cache and .ohpm-cache directories in .npmignore and .gitignore.

### Problem
In the GitHub Action publish workflow, BUN_INSTALL_CACHE_DIR is set to the workspace directory's .bun-cache folder. Because .bun-cache was not ignored in .npmignore, it was packaged into the published npm tarball for version 10.43.0, inflating the unpacked size to 429.4 MB and introducing over 38,000 cached dependency files.

### Solution
- Added .bun-cache and .ohpm-cache to .npmignore to exclude them from the published npm packages.
- Added them to .gitignore to avoid tracking them locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files to exclude additional local cache and hidden directories from version control and package publishing.
  * Reduced the chance of accidentally committing or distributing temporary development artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->