### PR TITLE
perf(harmony): run patch/cleanup off the UI thread via async NAPI (HM-1)

### DIFF
--- a/harmony/pushy/src/main/cpp/pushy.cpp
+++ b/harmony/pushy/src/main/cpp/pushy.cpp
@@ -727,6 +727,19 @@ napi_value BuildCopyGroups(napi_env env, napi_callback_info info) {
 // back on the JS thread.
 // ---------------------------------------------------------------------------
 
+// Reject an already-created deferred with an Error(message). Used when async
+// work fails to be created/queued, so the Promise never hangs pending.
+void RejectDeferredWithMessage(
+    napi_env env,
+    napi_deferred deferred,
+    const char* message) {
+  napi_value error = nullptr;
+  napi_value message_value = nullptr;
+  napi_create_string_utf8(env, message, NAPI_AUTO_LENGTH, &message_value);
+  napi_create_error(env, nullptr, message_value, &error);
+  napi_reject_deferred(env, deferred, error);
+}
+
 struct ApplyPatchWork {
   napi_async_work work = nullptr;
   napi_deferred deferred = nullptr;
@@ -803,34 +816,48 @@ napi_value ApplyPatchFromFileSource(napi_env env, napi_callback_info info) {
   napi_value resource_name = nullptr;
   napi_create_string_utf8(
       env, "applyPatchFromFileSource", NAPI_AUTO_LENGTH, &resource_name);
-  napi_create_async_work(
-      env,
-      nullptr,
-      resource_name,
-      [](napi_env, void* data) {
-        auto* w = static_cast<ApplyPatchWork*>(data);
-        w->status = pushy::patch::ApplyPatchFromFileSource(w->options);
-      },
-      [](napi_env cb_env, napi_status, void* data) {
-        auto* w = static_cast<ApplyPatchWork*>(data);
-        if (w->status.ok) {
-          napi_value undefined_value = nullptr;
-          napi_get_undefined(cb_env, &undefined_value);
-          napi_resolve_deferred(cb_env, w->deferred, undefined_value);
-        } else {
-          napi_value error = nullptr;
-          napi_value message = nullptr;
-          napi_create_string_utf8(
-              cb_env, w->status.message.c_str(), NAPI_AUTO_LENGTH, &message);
-          napi_create_error(cb_env, nullptr, message, &error);
-          napi_reject_deferred(cb_env, w->deferred, error);
-        }
-        napi_delete_async_work(cb_env, w->work);
-        delete w;
-      },
-      work_data,
-      &work_data->work);
-  napi_queue_async_work(env, work_data->work);
+  if (napi_create_async_work(
+          env,
+          nullptr,
+          resource_name,
+          [](napi_env, void* data) {
+            auto* w = static_cast<ApplyPatchWork*>(data);
+            w->status = pushy::patch::ApplyPatchFromFileSource(w->options);
+          },
+          [](napi_env cb_env, napi_status, void* data) {
+            auto* w = static_cast<ApplyPatchWork*>(data);
+            if (w->status.ok) {
+              napi_value undefined_value = nullptr;
+              napi_get_undefined(cb_env, &undefined_value);
+              napi_resolve_deferred(cb_env, w->deferred, undefined_value);
+            } else {
+              napi_value error = nullptr;
+              napi_value message = nullptr;
+              napi_create_string_utf8(
+                  cb_env, w->status.message.c_str(), NAPI_AUTO_LENGTH, &message);
+              napi_create_error(cb_env, nullptr, message, &error);
+              napi_reject_deferred(cb_env, w->deferred, error);
+            }
+            napi_delete_async_work(cb_env, w->work);
+            delete w;
+          },
+          work_data,
+          &work_data->work) != napi_ok) {
+    // Work was never created: settle the promise and free the data so it does
+    // not leak / hang pending forever.
+    RejectDeferredWithMessage(
+        env, work_data->deferred, "Unable to create async work");
+    delete work_data;
+    return promise;
+  }
+  if (napi_queue_async_work(env, work_data->work) != napi_ok) {
+    // Queued failed: the complete callback will never run, so clean up here.
+    napi_delete_async_work(env, work_data->work);
+    RejectDeferredWithMessage(
+        env, work_data->deferred, "Unable to queue async work");
+    delete work_data;
+    return promise;
+  }
   return promise;
 }
 
@@ -876,35 +903,46 @@ napi_value CleanupOldEntries(napi_env env, napi_callback_info info) {
   napi_value resource_name = nullptr;
   napi_create_string_utf8(
       env, "cleanupOldEntries", NAPI_AUTO_LENGTH, &resource_name);
-  napi_create_async_work(
-      env,
-      nullptr,
-      resource_name,
-      [](napi_env, void* data) {
-        auto* w = static_cast<CleanupWork*>(data);
-        w->status = pushy::patch::CleanupOldEntries(
-            w->root_dir, w->keep_current, w->keep_previous, w->max_age_days);
-      },
-      [](napi_env cb_env, napi_status, void* data) {
-        auto* w = static_cast<CleanupWork*>(data);
-        if (w->status.ok) {
-          napi_value undefined_value = nullptr;
-          napi_get_undefined(cb_env, &undefined_value);
-          napi_resolve_deferred(cb_env, w->deferred, undefined_value);
-        } else {
-          napi_value error = nullptr;
-          napi_value message = nullptr;
-          napi_create_string_utf8(
-              cb_env, w->status.message.c_str(), NAPI_AUTO_LENGTH, &message);
-          napi_create_error(cb_env, nullptr, message, &error);
-          napi_reject_deferred(cb_env, w->deferred, error);
-        }
-        napi_delete_async_work(cb_env, w->work);
-        delete w;
-      },
-      work_data,
-      &work_data->work);
-  napi_queue_async_work(env, work_data->work);
+  if (napi_create_async_work(
+          env,
+          nullptr,
+          resource_name,
+          [](napi_env, void* data) {
+            auto* w = static_cast<CleanupWork*>(data);
+            w->status = pushy::patch::CleanupOldEntries(
+                w->root_dir, w->keep_current, w->keep_previous, w->max_age_days);
+          },
+          [](napi_env cb_env, napi_status, void* data) {
+            auto* w = static_cast<CleanupWork*>(data);
+            if (w->status.ok) {
+              napi_value undefined_value = nullptr;
+              napi_get_undefined(cb_env, &undefined_value);
+              napi_resolve_deferred(cb_env, w->deferred, undefined_value);
+            } else {
+              napi_value error = nullptr;
+              napi_value message = nullptr;
+              napi_create_string_utf8(
+                  cb_env, w->status.message.c_str(), NAPI_AUTO_LENGTH, &message);
+              napi_create_error(cb_env, nullptr, message, &error);
+              napi_reject_deferred(cb_env, w->deferred, error);
+            }
+            napi_delete_async_work(cb_env, w->work);
+            delete w;
+          },
+          work_data,
+          &work_data->work) != napi_ok) {
+    RejectDeferredWithMessage(
+        env, work_data->deferred, "Unable to create async work");
+    delete work_data;
+    return promise;
+  }
+  if (napi_queue_async_work(env, work_data->work) != napi_ok) {
+    napi_delete_async_work(env, work_data->work);
+    RejectDeferredWithMessage(
+        env, work_data->deferred, "Unable to queue async work");
+    delete work_data;
+    return promise;
+  }
   return promise;
 }
 

--- a/harmony/pushy/src/main/cpp/pushy.cpp
+++ b/harmony/pushy/src/main/cpp/pushy.cpp
@@ -716,6 +716,34 @@ napi_value BuildCopyGroups(napi_env env, napi_callback_info info) {
   return NewCopyGroupArray(env, groups);
 }
 
+// ---------------------------------------------------------------------------
+// Async work plumbing for the heavy patch operations.
+//
+// applyPatchFromFileSource and cleanupOldEntries run hdiff / recursive file IO
+// that can take hundreds of ms to seconds. The Pushy TurboModule executes on
+// the UI thread, so running these synchronously froze the UI. These are now
+// wrapped in napi_create_async_work: arguments are parsed on the JS thread, the
+// heavy work runs on a libuv worker thread, and the returned Promise is settled
+// back on the JS thread.
+// ---------------------------------------------------------------------------
+
+struct ApplyPatchWork {
+  napi_async_work work = nullptr;
+  napi_deferred deferred = nullptr;
+  pushy::patch::FileSourcePatchOptions options;
+  pushy::patch::Status status{false, ""};
+};
+
+struct CleanupWork {
+  napi_async_work work = nullptr;
+  napi_deferred deferred = nullptr;
+  std::string root_dir;
+  std::string keep_current;
+  std::string keep_previous;
+  int32_t max_age_days = 0;
+  pushy::patch::Status status{false, ""};
+};
+
 napi_value ApplyPatchFromFileSource(napi_env env, napi_callback_info info) {
   napi_value args[1] = {nullptr};
   size_t argc = 1;
@@ -755,26 +783,55 @@ napi_value ApplyPatchFromFileSource(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
-  pushy::patch::FileSourcePatchOptions options;
-  options.manifest = BuildManifest(copy_froms, copy_tos, deletes);
-  options.source_root = source_root;
-  options.target_root = target_root;
-  options.origin_bundle_path = origin_bundle_path;
-  options.bundle_patch_path = bundle_patch_path;
-  options.bundle_output_path = bundle_output_path;
-  options.merge_source_subdir = merge_source_subdir;
-  options.enable_merge = enable_merge;
+  auto* work_data = new ApplyPatchWork();
+  work_data->options.manifest = BuildManifest(copy_froms, copy_tos, deletes);
+  work_data->options.source_root = source_root;
+  work_data->options.target_root = target_root;
+  work_data->options.origin_bundle_path = origin_bundle_path;
+  work_data->options.bundle_patch_path = bundle_patch_path;
+  work_data->options.bundle_output_path = bundle_output_path;
+  work_data->options.merge_source_subdir = merge_source_subdir;
+  work_data->options.enable_merge = enable_merge;
 
-  const pushy::patch::Status status =
-      pushy::patch::ApplyPatchFromFileSource(options);
-  if (!status.ok) {
-    ThrowError(env, status.message);
+  napi_value promise = nullptr;
+  if (napi_create_promise(env, &work_data->deferred, &promise) != napi_ok) {
+    delete work_data;
+    ThrowError(env, "Unable to create promise");
     return nullptr;
   }
 
-  napi_value undefined_value = nullptr;
-  napi_get_undefined(env, &undefined_value);
-  return undefined_value;
+  napi_value resource_name = nullptr;
+  napi_create_string_utf8(
+      env, "applyPatchFromFileSource", NAPI_AUTO_LENGTH, &resource_name);
+  napi_create_async_work(
+      env,
+      nullptr,
+      resource_name,
+      [](napi_env, void* data) {
+        auto* w = static_cast<ApplyPatchWork*>(data);
+        w->status = pushy::patch::ApplyPatchFromFileSource(w->options);
+      },
+      [](napi_env cb_env, napi_status, void* data) {
+        auto* w = static_cast<ApplyPatchWork*>(data);
+        if (w->status.ok) {
+          napi_value undefined_value = nullptr;
+          napi_get_undefined(cb_env, &undefined_value);
+          napi_resolve_deferred(cb_env, w->deferred, undefined_value);
+        } else {
+          napi_value error = nullptr;
+          napi_value message = nullptr;
+          napi_create_string_utf8(
+              cb_env, w->status.message.c_str(), NAPI_AUTO_LENGTH, &message);
+          napi_create_error(cb_env, nullptr, message, &error);
+          napi_reject_deferred(cb_env, w->deferred, error);
+        }
+        napi_delete_async_work(cb_env, w->work);
+        delete w;
+      },
+      work_data,
+      &work_data->work);
+  napi_queue_async_work(env, work_data->work);
+  return promise;
 }
 
 napi_value CleanupOldEntries(napi_env env, napi_callback_info info) {
@@ -803,19 +860,52 @@ napi_value CleanupOldEntries(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
-  const pushy::patch::Status status = pushy::patch::CleanupOldEntries(
-      root_dir,
-      keep_current,
-      keep_previous,
-      max_age_days);
-  if (!status.ok) {
-    ThrowError(env, status.message);
+  auto* work_data = new CleanupWork();
+  work_data->root_dir = root_dir;
+  work_data->keep_current = keep_current;
+  work_data->keep_previous = keep_previous;
+  work_data->max_age_days = max_age_days;
+
+  napi_value promise = nullptr;
+  if (napi_create_promise(env, &work_data->deferred, &promise) != napi_ok) {
+    delete work_data;
+    ThrowError(env, "Unable to create promise");
     return nullptr;
   }
 
-  napi_value undefined_value = nullptr;
-  napi_get_undefined(env, &undefined_value);
-  return undefined_value;
+  napi_value resource_name = nullptr;
+  napi_create_string_utf8(
+      env, "cleanupOldEntries", NAPI_AUTO_LENGTH, &resource_name);
+  napi_create_async_work(
+      env,
+      nullptr,
+      resource_name,
+      [](napi_env, void* data) {
+        auto* w = static_cast<CleanupWork*>(data);
+        w->status = pushy::patch::CleanupOldEntries(
+            w->root_dir, w->keep_current, w->keep_previous, w->max_age_days);
+      },
+      [](napi_env cb_env, napi_status, void* data) {
+        auto* w = static_cast<CleanupWork*>(data);
+        if (w->status.ok) {
+          napi_value undefined_value = nullptr;
+          napi_get_undefined(cb_env, &undefined_value);
+          napi_resolve_deferred(cb_env, w->deferred, undefined_value);
+        } else {
+          napi_value error = nullptr;
+          napi_value message = nullptr;
+          napi_create_string_utf8(
+              cb_env, w->status.message.c_str(), NAPI_AUTO_LENGTH, &message);
+          napi_create_error(cb_env, nullptr, message, &error);
+          napi_reject_deferred(cb_env, w->deferred, error);
+        }
+        napi_delete_async_work(cb_env, w->work);
+        delete w;
+      },
+      work_data,
+      &work_data->work);
+  napi_queue_async_work(env, work_data->work);
+  return promise;
 }
 
 bool ExportFunction(

--- a/harmony/pushy/src/main/ets/DownloadTask.ts
+++ b/harmony/pushy/src/main/ets/DownloadTask.ts
@@ -233,7 +233,7 @@ export class DownloadTask {
     const originBundlePath = `${workingDirectory}/${TEMP_ORIGIN_BUNDLE_ENTRY}`;
     try {
       await this.writeFileContent(originBundlePath, originContent);
-      NativePatchCore.applyPatchFromFileSource({
+      await NativePatchCore.applyPatchFromFileSource({
         copyFroms: [],
         copyTos: [],
         deletes: [],
@@ -568,7 +568,7 @@ export class DownloadTask {
       manifestArrays.deletes,
       HARMONY_BUNDLE_PATCH_ENTRY,
     );
-    NativePatchCore.applyPatchFromFileSource({
+    await NativePatchCore.applyPatchFromFileSource({
       copyFroms: manifestArrays.copyFroms,
       copyTos: manifestArrays.copyTos,
       deletes: manifestArrays.deletes,
@@ -664,7 +664,7 @@ export class DownloadTask {
 
   private async doCleanUp(params: DownloadTaskParams): Promise<void> {
     try {
-      NativePatchCore.cleanupOldEntries(
+      await NativePatchCore.cleanupOldEntries(
         params.unzipDirectory,
         params.hash || '',
         params.originHash || '',

--- a/harmony/pushy/src/main/ets/NativePatchCore.ts
+++ b/harmony/pushy/src/main/ets/NativePatchCore.ts
@@ -75,13 +75,13 @@ interface NativePatchCoreBindings {
     bundlePatchEntryName?: string,
   ): ArchivePatchPlanResult;
   buildCopyGroups(copyFroms: string[], copyTos: string[]): CopyGroupResult[];
-  applyPatchFromFileSource(options: FileSourcePatchRequest): void;
+  applyPatchFromFileSource(options: FileSourcePatchRequest): Promise<void>;
   cleanupOldEntries(
     rootDir: string,
     keepCurrent: string,
     keepPrevious: string,
     maxAgeDays: number,
-  ): void;
+  ): Promise<void>;
 }
 
 export default NativeUpdateCore as unknown as NativePatchCoreBindings;

--- a/harmony/pushy/src/main/ets/UpdateContext.ts
+++ b/harmony/pushy/src/main/ets/UpdateContext.ts
@@ -520,12 +520,18 @@ export class UpdateContext {
 
   public cleanUp(): void {
     const state = this.getStateSnapshot();
+    // cleanupOldEntries now runs on a native worker thread (returns a Promise).
+    // Cleanup is best-effort background maintenance and no caller depends on its
+    // completion, so fire-and-forget it off the UI thread and just log failures
+    // instead of blocking the state operation (or cold start) on disk I/O.
     NativePatchCore.cleanupOldEntries(
       this.rootDir,
       state.currentVersion || '',
       state.lastVersion || '',
       3,
-    );
+    ).catch((error: Object) => {
+      console.error('cleanupOldEntries failed:', error);
+    });
   }
 
   public getIsUsingBundleUrl(): boolean {


### PR DESCRIPTION
## 背景

代码审计发现 HM-1：Pushy 的 HarmonyOS TurboModule 跑在 UI 线程，而 `applyPatchFromFileSource` / `cleanupOldEntries` 是**同步 NAPI 调用**——hdiff 打补丁和递归清理会把 UI 冻结数百 ms 到数秒。Android 端同样的工作本来就在后台线程，本 PR 补齐这一平台差距。

## 改动

- **C++**（`harmony/pushy/src/main/cpp/pushy.cpp`）：把 `ApplyPatchFromFileSource` / `CleanupOldEntries` 用 `napi_create_async_work` 包成异步、返回 Promise。参数在 JS 线程解析；hdiff/清理在 libuv worker 线程执行；Promise 在 JS 线程 resolve/reject。
- **ArkTS 绑定**（`NativePatchCore.ts`）：两个方法返回类型改 `Promise<void>`；`DownloadTask.ts` 全部调用点 `await`。
- **`UpdateContext.cleanUp()`**：保持 `void` 签名（所有调用方本就是 fire-and-forget），内部改为发起 Promise + `.catch` 记日志，冷启动 `syncStateWithBinaryVersion → cleanUp` 不再阻塞在同步磁盘 I/O（HM-1 点③随之解决）。

## 验证说明

⚠️ **CI 无 HarmonyOS runner，本地也无 Harmony 设备/模拟器，本 PR 未经运行时验证**（按维护者指示直接实现）。已确认：共享 C++ patch_core 15 个单测仍全过、Android JNI glue 语法校验无误（改动隔离在 Harmony 层）。

**待真机验证**：完整"下载 → 打补丁 → 切版本 → 重启 → markSuccess"链路，重点确认打补丁期间 UI 不再冻结、async work 生命周期与错误传播正确。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Patch application and cleanup are now asynchronous, returning Promises to improve responsiveness during update operations.
  * Cleanup runs in the background without blocking the caller.

* **Bug Fixes**
  * Ensured patch and cleanup operations are properly awaited so subsequent steps run only after native work completes.
  * Added best-effort error handling for background cleanup (failures are logged without interrupting the main process).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->